### PR TITLE
Implement Firestore VM helpers with tests

### DIFF
--- a/apps/functions/firestore.js
+++ b/apps/functions/firestore.js
@@ -2,4 +2,33 @@ import { Firestore } from "@google-cloud/firestore"
 
 const db = new Firestore()
 
-export const vms = () => db.collection("vms")
+export const vms = (database = db) => database.collection("vms")
+
+export const listVms = async (database = db) => {
+  const snapshot = await vms(database).orderBy("name").get()
+  return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }))
+}
+
+export const claimVm = async (vmName, user, minutes = 120, database = db) => {
+  const vmRef = vms(database).doc(vmName)
+  const now = new Date()
+
+  return database.runTransaction(async tx => {
+    const vmDoc = await tx.get(vmRef)
+    const data = vmDoc.exists ? vmDoc.data() : {}
+
+    if (data.assignedTo && data.endAt && data.endAt > now) {
+      throw new Error("VM already claimed")
+    }
+
+    const startAt = now
+    const endAt = new Date(now.getTime() + minutes * 60000)
+
+    tx.update(vmRef, { assignedTo: user, startAt, endAt })
+
+    return { assignedTo: user, startAt, endAt }
+  })
+}
+
+export const releaseVm = (vmName, database = db) =>
+  vms(database).doc(vmName).update({ assignedTo: null, startAt: null, endAt: null })

--- a/apps/functions/firestore.test.js
+++ b/apps/functions/firestore.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { claimVm, releaseVm } from './firestore.js'
+
+const mockDb = store => ({
+  collection: () => ({
+    doc: id => ({ id })
+  }),
+  runTransaction: async fn => {
+    const tx = {
+      get: async ref => ({ exists: true, data: () => store[ref.id] }),
+      update: (ref, data) => {
+        store[ref.id] = { ...store[ref.id], ...data }
+      }
+    }
+    return fn(tx)
+  }
+})
+
+test('claimVm assigns free VM', async () => {
+  const store = { vm1: {} }
+  const db = mockDb(store)
+
+  const result = await claimVm('vm1', 'alice', 60, db)
+
+  assert.strictEqual(store.vm1.assignedTo, 'alice')
+  assert.ok(store.vm1.startAt instanceof Date)
+  assert.ok(store.vm1.endAt instanceof Date)
+  assert.strictEqual(result.assignedTo, 'alice')
+})
+
+test('claimVm rejects if VM already claimed', async () => {
+  const future = new Date(Date.now() + 1000)
+  const store = { vm1: { assignedTo: 'bob', endAt: future } }
+  const db = mockDb(store)
+
+  await assert.rejects(claimVm('vm1', 'alice', 60, db))
+})
+
+test('releaseVm clears assignment', async () => {
+  const store = { vm1: { assignedTo: 'alice', startAt: new Date(), endAt: new Date() } }
+  const db = {
+    collection: () => ({
+      doc: id => ({
+        update: data => {
+          store[id] = { ...store[id], ...data }
+        }
+      })
+    })
+  }
+
+  await releaseVm('vm1', db)
+
+  assert.deepStrictEqual(store.vm1, { assignedTo: null, startAt: null, endAt: null })
+})
+


### PR DESCRIPTION
## Summary
- add Firestore helpers for listing, claiming, and releasing VMs
- prevent double-claim with transactional check
- add unit tests for claim success/conflict and release logic

## Testing
- `npm run lint`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a8d7d25ddc832d84d2d01a890b816e