### PR TITLE
feat(webex): add webhook signature verification and token handling

### DIFF
--- a/apps/functions/index.js
+++ b/apps/functions/index.js
@@ -1,5 +1,52 @@
+import {init, verifySignature, webexGet, getBotId} from './webex.js'
+import {parseCommand} from './vm-commands.js'
+
+const handleCommand = async (roomId, text) => {
+  const cmd = parseCommand(text)
+  if (!cmd) return
+  console.log('command', cmd)
+}
+
 export const webexHooks = async (req, res) => {
-  res.status(200).send("ok")
+  try {
+    await init()
+    const signature = req.get('x-spark-signature') || ''
+    const raw = req.rawBody
+    if (!verifySignature(raw, signature)) {
+      console.warn('invalid signature')
+      res.status(401).send('invalid signature')
+      return
+    }
+
+    const {resource, event, data} = req.body
+
+    if (resource === 'messages' && event === 'created') {
+      try {
+        const msg = await webexGet(`/messages/${data.id}`)
+        if (msg.personId === getBotId()) {
+          res.status(200).send('ok')
+          return
+        }
+        await handleCommand(msg.roomId, msg.text || '')
+      } catch (err) {
+        console.error('message handling error', err)
+      }
+    }
+
+    if (resource === 'attachmentActions' && event === 'created') {
+      try {
+        const action = await webexGet(`/attachment/actions/${data.id}`)
+        await handleCommand(action.roomId, action.inputs?.command || '')
+      } catch (err) {
+        console.error('attachment action error', err)
+      }
+    }
+
+    res.status(200).send('ok')
+  } catch (err) {
+    console.error('webexHooks error', err)
+    res.status(500).send('error')
+  }
 }
 
 export const cleanup = async () => {}

--- a/apps/functions/vm-commands.js
+++ b/apps/functions/vm-commands.js
@@ -1,1 +1,7 @@
-export const parseCommand = () => {}
+export const parseCommand = text => {
+  const t = (text || '').trim()
+  if (!t.startsWith('/vm')) return null
+  const parts = t.slice(3).trim().split(/\s+/)
+  const action = parts.shift()?.toLowerCase()
+  return {action, args: parts}
+}

--- a/apps/functions/webex.js
+++ b/apps/functions/webex.js
@@ -1,2 +1,57 @@
-export const verifySignature = () => {}
-export const postMessage = async () => {}
+import crypto from 'node:crypto'
+import {SecretManagerServiceClient} from '@google-cloud/secret-manager'
+
+const secrets = new SecretManagerServiceClient()
+let botToken
+let botId
+const webhookSecret = process.env.WEBEX_WEBHOOK_SECRET
+const baseUrl = 'https://webexapis.com/v1'
+
+export const init = async () => {
+  if (botToken) return
+  const name = process.env.WEBEX_BOT_TOKEN_SECRET
+  if (!name) throw new Error('WEBEX_BOT_TOKEN_SECRET not set')
+  const [version] = await secrets.accessSecretVersion({name})
+  botToken = version.payload.data.toString()
+  const res = await fetch(`${baseUrl}/people/me`, {
+    headers: {Authorization: `Bearer ${botToken}`}
+  })
+  const me = await res.json()
+  botId = me.id
+}
+
+export const getBotId = () => botId
+
+export const verifySignature = (raw, signature = '') => {
+  if (!webhookSecret || !raw || !signature) return false
+  const hmac = crypto.createHmac('sha1', webhookSecret)
+  hmac.update(raw)
+  const digest = hmac.digest('hex')
+  return digest === signature
+}
+
+export const webexGet = async path => {
+  await init()
+  const res = await fetch(`${baseUrl}${path}`, {
+    headers: {Authorization: `Bearer ${botToken}`}
+  })
+  if (!res.ok) throw new Error(`GET ${path} ${res.status}`)
+  return res.json()
+}
+
+export const webexPost = async (path, body) => {
+  await init()
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${botToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  })
+  if (!res.ok) throw new Error(`POST ${path} ${res.status}`)
+  return res.json()
+}
+
+export const sendText = (roomId, markdown) =>
+  webexPost('/messages', {roomId, markdown})

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "webex-vm-reservations",
       "version": "0.1.0",
       "dependencies": {
-        "@google-cloud/firestore": "^7.6.0"
+        "@google-cloud/firestore": "^7.6.0",
+        "@google-cloud/secret-manager": "^5.0.0"
       },
       "devDependencies": {
         "@google-cloud/functions-framework": "^4.0.0",
@@ -195,6 +196,18 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-5.6.0.tgz",
+      "integrity": "sha512-0daW/OXQEVc6VQKPyJTQNyD+563I/TYQ7GCQJx4dq3lB666R9FUPvqHx9b/o/qQtZ5pfuoCbGZl3krpxgTSW8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "deploy:cleanup": "gcloud functions deploy cleanup --gen2 --runtime=nodejs20 --region=us-central1 --source=apps/functions --entry-point=cleanup --schedule='*/5 * * * *'"
   },
   "dependencies": {
-    "@google-cloud/firestore": "^7.6.0"
+    "@google-cloud/firestore": "^7.6.0",
+    "@google-cloud/secret-manager": "^5.0.0"
   },
   "devDependencies": {
     "@google-cloud/functions-framework": "^4.0.0",


### PR DESCRIPTION
## Summary
- verify Webex webhook signatures with HMAC secret
- fetch bot token from Secret Manager and wrap Webex API calls
- handle message and card action events in webexHooks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8dab1ed3c832d8dc49761579b8b09