### PR TITLE
feat: cleanup expired VM reservations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ npm run deploy:webex
 npm run deploy:cleanup
 ```
 
+Create a Cloud Scheduler job to run cleanup every 5 minutes:
+
+```sh
+gcloud scheduler jobs create http vm-cleanup \
+  --schedule="*/5 * * * *" \
+  --http-method=GET \
+  --uri=$(gcloud functions describe cleanup --gen2 --region=us-central1 --format="value(serviceConfig.uri)") \
+  --oidc-service-account-email=$(gcloud config get account)
+```
+
 ## Scripts
 
 - `npm run lint` – run ESLint

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "seed": "node scripts/seed.js",
     "dev": "functions-framework --target=webexHooks",
     "deploy:webex": "gcloud functions deploy webexHooks --gen2 --runtime=nodejs20 --region=us-central1 --source=apps/functions --entry-point=webexHooks --trigger-http --allow-unauthenticated",
-    "deploy:cleanup": "gcloud functions deploy cleanup --gen2 --runtime=nodejs20 --region=us-central1 --source=apps/functions --entry-point=cleanup --schedule='*/5 * * * *'"
+    "deploy:cleanup": "gcloud functions deploy cleanup --gen2 --runtime=nodejs20 --region=us-central1 --source=apps/functions --entry-point=cleanup --trigger-http --no-allow-unauthenticated"
   },
   "dependencies": {
     "@google-cloud/firestore": "^7.6.0",


### PR DESCRIPTION
## Summary
- add scheduled cleanup function to release expired VM reservations
- document Cloud Scheduler job using OIDC to invoke cleanup
- deploy cleanup as authenticated HTTP function

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8debd438c832d8daeb04f50b43475