### PR TITLE
Add deploy commands and first-run checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,62 @@
 
 Minimal project scaffold for a Webex bot that manages lab VMs.
 
-## Setup
+## First-run checklist
 
-1. Create a Firestore database in **Native mode**.
-2. Store your secrets in Secret Manager:
+1. Enable required APIs:
    ```sh
-   gcloud secrets create WEBEX_BOT_TOKEN --data-file=-
-   gcloud secrets create WEBEX_WEBHOOK_SECRET --data-file=-
+   gcloud services enable \
+     cloudfunctions.googleapis.com \
+     artifactregistry.googleapis.com \
+     run.googleapis.com \
+     eventarc.googleapis.com \
+     secretmanager.googleapis.com \
+     firestore.googleapis.com \
+     cloudscheduler.googleapis.com
+   ```
+2. Create a Firestore database in **Native mode**.
+3. Create secrets:
+   ```sh
+   echo 'BOT_TOKEN' | gcloud secrets create WEBEX_BOT_TOKEN --data-file=-
+   echo 'WEBHOOK_SECRET' | gcloud secrets create WEBEX_WEBHOOK_SECRET --data-file=-
+   ```
+4. Deploy Cloud Functions (2nd gen, Node 20):
+
+   ```sh
+   gcloud functions deploy webexHooks \
+     --gen2 --runtime=nodejs20 --region=us-central1 \
+     --source=apps/functions --entry-point=webexHooks \
+     --trigger-http --allow-unauthenticated \
+     --service-account=<SA_EMAIL> \
+     --set-secrets=WEBEX_BOT_TOKEN=WEBEX_BOT_TOKEN:latest,WEBEX_WEBHOOK_SECRET=WEBEX_WEBHOOK_SECRET:latest
+
+   gcloud functions deploy cleanup \
+     --gen2 --runtime=nodejs20 --region=us-central1 \
+     --source=apps/functions --entry-point=cleanup \
+     --trigger-http --no-allow-unauthenticated \
+     --service-account=<SA_EMAIL>
    ```
 
-## Deploy
+5. Seed Firestore with placeholder VMs:
+   ```sh
+   npm run seed
+   ```
+6. Register Webex webhooks (messages + attachmentActions) to the `webexHooks` URL:
+   ```sh
+   WEBHOOK_URL=$(gcloud functions describe webexHooks --gen2 --region=us-central1 --format="value(serviceConfig.uri)")
+   WEBEX_TOKEN=$(gcloud secrets versions access latest --secret=WEBEX_BOT_TOKEN)
+   curl https://webexapis.com/v1/webhooks \
+     -H "Authorization: Bearer $WEBEX_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d "{\"name\":\"vm-messages\",\"targetUrl\":\"$WEBHOOK_URL\",\"resource\":\"messages\",\"event\":\"created\"}"
+   curl https://webexapis.com/v1/webhooks \
+     -H "Authorization: Bearer $WEBEX_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d "{\"name\":\"vm-actions\",\"targetUrl\":\"$WEBHOOK_URL\",\"resource\":\"attachmentActions\",\"event\":\"created\"}"
+   ```
+7. In your Webex space, send `/vm list`.
 
-Deploy Cloud Functions (2nd gen, Node 20):
-
-```sh
-npm run deploy:webex
-npm run deploy:cleanup
-```
+## Cleanup scheduler
 
 Create a Cloud Scheduler job to run cleanup every 5 minutes:
 

--- a/apps/functions/webex.js
+++ b/apps/functions/webex.js
@@ -1,20 +1,14 @@
-import crypto from 'node:crypto'
-import {SecretManagerServiceClient} from '@google-cloud/secret-manager'
-
-const secrets = new SecretManagerServiceClient()
-let botToken
+import crypto from "node:crypto"
+let botToken = process.env.WEBEX_BOT_TOKEN
 let botId
 const webhookSecret = process.env.WEBEX_WEBHOOK_SECRET
-const baseUrl = 'https://webexapis.com/v1'
+const baseUrl = "https://webexapis.com/v1"
 
 export const init = async () => {
-  if (botToken) return
-  const name = process.env.WEBEX_BOT_TOKEN_SECRET
-  if (!name) throw new Error('WEBEX_BOT_TOKEN_SECRET not set')
-  const [version] = await secrets.accessSecretVersion({name})
-  botToken = version.payload.data.toString()
+  if (botId) return
+  if (!botToken) throw new Error("WEBEX_BOT_TOKEN not set")
   const res = await fetch(`${baseUrl}/people/me`, {
-    headers: {Authorization: `Bearer ${botToken}`}
+    headers: { Authorization: `Bearer ${botToken}` },
   })
   const me = await res.json()
   botId = me.id
@@ -22,18 +16,18 @@ export const init = async () => {
 
 export const getBotId = () => botId
 
-export const verifySignature = (raw, signature = '') => {
+export const verifySignature = (raw, signature = "") => {
   if (!webhookSecret || !raw || !signature) return false
-  const hmac = crypto.createHmac('sha1', webhookSecret)
+  const hmac = crypto.createHmac("sha1", webhookSecret)
   hmac.update(raw)
-  const digest = hmac.digest('hex')
+  const digest = hmac.digest("hex")
   return digest === signature
 }
 
-export const webexGet = async path => {
+export const webexGet = async (path) => {
   await init()
   const res = await fetch(`${baseUrl}${path}`, {
-    headers: {Authorization: `Bearer ${botToken}`}
+    headers: { Authorization: `Bearer ${botToken}` },
   })
   if (!res.ok) throw new Error(`GET ${path} ${res.status}`)
   return res.json()
@@ -42,16 +36,16 @@ export const webexGet = async path => {
 export const webexPost = async (path, body) => {
   await init()
   const res = await fetch(`${baseUrl}${path}`, {
-    method: 'POST',
+    method: "POST",
     headers: {
       Authorization: `Bearer ${botToken}`,
-      'Content-Type': 'application/json'
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
   })
   if (!res.ok) throw new Error(`POST ${path} ${res.status}`)
   return res.json()
 }
 
 export const sendText = (roomId, markdown) =>
-  webexPost('/messages', {roomId, markdown})
+  webexPost("/messages", { roomId, markdown })

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,7 @@
       "name": "webex-vm-reservations",
       "version": "0.1.0",
       "dependencies": {
-        "@google-cloud/firestore": "^7.6.0",
-        "@google-cloud/secret-manager": "^5.0.0"
+        "@google-cloud/firestore": "^7.6.0"
       },
       "devDependencies": {
         "@google-cloud/functions-framework": "^4.0.0",
@@ -196,18 +195,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@google-cloud/secret-manager": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-5.6.0.tgz",
-      "integrity": "sha512-0daW/OXQEVc6VQKPyJTQNyD+563I/TYQ7GCQJx4dq3lB666R9FUPvqHx9b/o/qQtZ5pfuoCbGZl3krpxgTSW8Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-gax": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,11 @@
     "format": "prettier --write .",
     "seed": "node scripts/seed.js",
     "dev": "functions-framework --target=webexHooks",
-    "deploy:webex": "gcloud functions deploy webexHooks --gen2 --runtime=nodejs20 --region=us-central1 --source=apps/functions --entry-point=webexHooks --trigger-http --allow-unauthenticated",
-    "deploy:cleanup": "gcloud functions deploy cleanup --gen2 --runtime=nodejs20 --region=us-central1 --source=apps/functions --entry-point=cleanup --trigger-http --no-allow-unauthenticated"
+    "deploy:webex": "gcloud functions deploy webexHooks --gen2 --runtime=nodejs20 --region=us-central1 --source=apps/functions --entry-point=webexHooks --trigger-http --allow-unauthenticated --service-account=$SA_EMAIL --set-secrets=WEBEX_BOT_TOKEN=WEBEX_BOT_TOKEN:latest,WEBEX_WEBHOOK_SECRET=WEBEX_WEBHOOK_SECRET:latest",
+    "deploy:cleanup": "gcloud functions deploy cleanup --gen2 --runtime=nodejs20 --region=us-central1 --source=apps/functions --entry-point=cleanup --trigger-http --no-allow-unauthenticated --service-account=$SA_EMAIL"
   },
   "dependencies": {
-    "@google-cloud/firestore": "^7.6.0",
-    "@google-cloud/secret-manager": "^5.0.0"
+    "@google-cloud/firestore": "^7.6.0"
   },
   "devDependencies": {
     "@google-cloud/functions-framework": "^4.0.0",


### PR DESCRIPTION
## Summary
- document first-run setup including enabling APIs, secrets, and Webex webhooks
- add gcloud deploy scripts with service account and secret mappings
- load bot token from environment instead of Secret Manager

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8e085bc88832db66605deafcfe1f4