### PR TITLE
Add verbose logging for Cloud Function troubleshooting

### DIFF
--- a/apps/functions/firestore.js
+++ b/apps/functions/firestore.js
@@ -5,19 +5,25 @@ const db = new Firestore()
 export const vms = (database = db) => database.collection("vms")
 
 export const listVms = async (database = db) => {
+  console.log("listing vms")
   const snapshot = await vms(database).orderBy("name").get()
-  return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }))
+  const results = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
+  console.log("found", results.length, "vms")
+  return results
 }
 
 export const claimVm = async (vmName, user, minutes = 120, database = db) => {
+  console.log("claiming vm", vmName, "for", user, "for", minutes, "minutes")
   const vmRef = vms(database).doc(vmName)
   const now = new Date()
 
-  return database.runTransaction(async tx => {
+  return database.runTransaction(async (tx) => {
     const vmDoc = await tx.get(vmRef)
     const data = vmDoc.exists ? vmDoc.data() : {}
+    console.log("current vm data", data)
 
     if (data.assignedTo && data.endAt && data.endAt > now) {
+      console.log("vm already claimed")
       throw new Error("VM already claimed")
     }
 
@@ -25,10 +31,15 @@ export const claimVm = async (vmName, user, minutes = 120, database = db) => {
     const endAt = new Date(now.getTime() + minutes * 60000)
 
     tx.update(vmRef, { assignedTo: user, startAt, endAt })
+    console.log("vm claimed until", endAt)
 
     return { assignedTo: user, startAt, endAt }
   })
 }
 
-export const releaseVm = (vmName, database = db) =>
-  vms(database).doc(vmName).update({ assignedTo: null, startAt: null, endAt: null })
+export const releaseVm = (vmName, database = db) => {
+  console.log("releasing vm", vmName)
+  return vms(database)
+    .doc(vmName)
+    .update({ assignedTo: null, startAt: null, endAt: null })
+}

--- a/apps/functions/webex.js
+++ b/apps/functions/webex.js
@@ -7,16 +7,19 @@ const baseUrl = "https://webexapis.com/v1"
 export const init = async () => {
   if (botId) return
   if (!botToken) throw new Error("WEBEX_BOT_TOKEN not set")
+  console.log("initializing webex client")
   const res = await fetch(`${baseUrl}/people/me`, {
     headers: { Authorization: `Bearer ${botToken}` },
   })
+  if (!res.ok) throw new Error(`init failed ${res.status}`)
   const me = await res.json()
   botId = me.id
+  console.log("webex client initialized with bot id", botId)
 }
 
 export const getBotId = () => botId
 
-export const verifySignature = (raw, signature = "") => {  
+export const verifySignature = (raw, signature = "") => {
   if (!webhookSecret || !raw || !signature) {
     console.warn("Missing required verification data")
     return false
@@ -25,21 +28,25 @@ export const verifySignature = (raw, signature = "") => {
   const hmac = crypto.createHmac("sha1", webhookSecret.trim())
   hmac.update(raw)
   const digest = hmac.digest("hex")
-  
-  return digest === signature
+  const ok = digest === signature
+  console.log("signature match", ok)
+  return ok
 }
 
 export const webexGet = async (path) => {
   await init()
+  console.log("webex GET", path)
   const res = await fetch(`${baseUrl}${path}`, {
     headers: { Authorization: `Bearer ${botToken}` },
   })
+  console.log("webex GET status", res.status)
   if (!res.ok) throw new Error(`GET ${path} ${res.status}`)
   return res.json()
 }
 
 export const webexPost = async (path, body) => {
   await init()
+  console.log("webex POST", path, body)
   const res = await fetch(`${baseUrl}${path}`, {
     method: "POST",
     headers: {
@@ -48,9 +55,12 @@ export const webexPost = async (path, body) => {
     },
     body: JSON.stringify(body),
   })
+  console.log("webex POST status", res.status)
   if (!res.ok) throw new Error(`POST ${path} ${res.status}`)
   return res.json()
 }
 
-export const sendText = (roomId, markdown) =>
-  webexPost("/messages", { roomId, markdown })
+export const sendText = (roomId, markdown) => {
+  console.log("sending text to", roomId)
+  return webexPost("/messages", { roomId, markdown })
+}


### PR DESCRIPTION
## Summary
- add detailed console logs to roster posting, command handling, and webhook processing
- log Firestore operations for listing, claiming, and releasing VMs
- log Webex client initialization, signature checks, and API requests

## Testing
- `npm run lint`
- `node --test apps/functions/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab6a8dd82c832d96c5296fe9c2009e