### PR TITLE
Render VM list in table and add refresh button

### DIFF
--- a/apps/functions/cards.js
+++ b/apps/functions/cards.js
@@ -7,11 +7,10 @@ const toDate = v => {
 
 const TZ = 'America/Chicago'
 
-export const rosterCard = vms => ({
-  type: 'AdaptiveCard',
-  $schema: 'https://adaptivecards.io/schemas/adaptive-card.json',
-  version: '1.3',
-  body: vms.flatMap(vm => {
+export const rosterCard = vms => {
+  const rows = []
+
+  const vmColumn = vm => {
     const endAt = toDate(vm.endAt)
     const inUse = vm.assignedTo && endAt && endAt > new Date()
 
@@ -43,16 +42,37 @@ export const rosterCard = vms => ({
           }
         ]
 
-    return [
+    return {
+      type: 'Column',
+      width: 'stretch',
+      items: [
+        {type: 'TextBlock', text: `**${vm.id}**: ${vm.name}`, size: 'Medium'},
+        {type: 'TextBlock', text: status, size: 'Small'},
+        {type: 'ActionSet', actions}
+      ]
+    }
+  }
+
+  for (let i = 0; i < vms.length; i += 2) {
+    const pair = vms.slice(i, i + 2)
+    rows.push({
+      type: 'ColumnSet',
+      separator: i > 0,
+      columns: pair.map(vmColumn)
+    })
+  }
+
+  return {
+    type: 'AdaptiveCard',
+    $schema: 'https://adaptivecards.io/schemas/adaptive-card.json',
+    version: '1.3',
+    body: rows,
+    actions: [
       {
-        type: 'Container',
-        separator: true,
-        items: [
-          {type: 'TextBlock', text: `**${vm.id}**: ${vm.name}`, size: 'Medium'},
-          {type: 'TextBlock', text: status, size: 'Small'},
-          {type: 'ActionSet', actions}
-        ]
-      },
+        type: 'Action.Submit',
+        title: 'Refresh',
+        data: {command: '/vm list'}
+      }
     ]
-  })
-})
+  }
+}


### PR DESCRIPTION
## Summary
- Render VM roster using a two-column table for easier scanning
- Add refresh action to quickly rerun `/vm list`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abba07e514832db0bb94284dc7fcbd